### PR TITLE
Add QQRM-only CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  reject:
+    if: ${{ github.event.pull_request.user.login != 'QQRM' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject untrusted PR
+        run: |
+          echo "Pull requests are only processed for user QQRM." >&2
+          exit 1
+
+  build:
+    if: ${{ github.event.pull_request.user.login == 'QQRM' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build extension
+        run: zip -r youtube-share-url-cleaner.zip . -x '*.git*' '*node_modules*' 'youtube-share-url-cleaner.zip' '*.DS_Store'

--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@
 После:
 
 [https://youtu.be/dQw4w9WgXcQ](https://youtu.be/dQw4w9WgXcQ)
+
+## CI
+
+Проверки GitHub Actions выполняются только для pull request-ов от пользователя
+`QQRM`. Для запросов от других аккаунтов workflow сразу завершается без
+выполнения задач и помечается как неуспешный.


### PR DESCRIPTION
## Summary
- remove trusted users text file
- gate CI workflow so it only runs for `QQRM`
- update README with new policy

## Testing
- `zip -r youtube-share-url-cleaner.zip . -x "*.git*" "*node_modules*" "youtube-share-url-cleaner.zip" "*.DS_Store"`

------
https://chatgpt.com/codex/tasks/task_e_688b893cf6708332bdfe2123569a164d